### PR TITLE
Prevent stationary bootstrap from exceeding length of array

### DIFF
--- a/recombinator/block_bootstrap.py
+++ b/recombinator/block_bootstrap.py
@@ -50,7 +50,7 @@ def _stationary_bootstrap_loop(block_length: float,
                 indices[b, t] = np.ceil(T * np.random.rand())
             else:
                 # continue current block for another time-step
-                indices[b, t] = indices[b, t - 1] + 1
+                indices[b, t] = indices[b, t - 1] + 1 % (2*T)
 
     return indices
 

--- a/recombinator/block_bootstrap.py
+++ b/recombinator/block_bootstrap.py
@@ -50,7 +50,7 @@ def _stationary_bootstrap_loop(block_length: float,
                 indices[b, t] = np.ceil(T * np.random.rand())
             else:
                 # continue current block for another time-step
-                indices[b, t] = indices[b, t - 1] + 1 % (2*T)
+                indices[b, t] = (indices[b, t - 1] + 1) % (2*T)
 
     return indices
 


### PR DESCRIPTION
I get an error that the index is 256 whilst x only has length 256. As x has length 2T, I just take the modulus to fix the error.