### PR TITLE
compatibility for numpy>1.20

### DIFF
--- a/recombinator/block_bootstrap.py
+++ b/recombinator/block_bootstrap.py
@@ -106,7 +106,7 @@ def stationary_bootstrap(x: np.ndarray,
         x = np.vstack((x, x))
 
     # allocate array for the indices into the source array
-    indices = np.zeros((replications, sub_sample_length), dtype=np.int)
+    indices = np.zeros((replications, sub_sample_length), dtype=int)
 
     # randomly initialize the beginning of the first block in each sub-sample
     indices[:, 0] = np.random.randint(T, size=(replications,))

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ URL = 'https://github.com/InvestmentSystems/recombinator'
 EMAIL = 'nowotnym@gmail.com'
 AUTHOR = 'Michael Christoph Nowotny'
 REQUIRES_PYTHON = '>=3.6.0'
-VERSION = "0.0.6.1"
+VERSION = "0.0.6.2"
 
 # What packages are required for this module to be executed?
 REQUIRED = [


### PR DESCRIPTION
Latest version of recombinator (0.0.6.1) has compatibility issue with numpy.
`np.int` has been depricated since numpy version 1.20 
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations